### PR TITLE
Add support for snapcraft building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+*.snap
 
 # Test binary, build with `go test -c`
 *.test

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: deucalion
+version: git
+summary: Query Prometheus
+description: |
+  A tool for querying a Prometheus instance for alerts and run commands based on the result.
+confinement: devmode
+base: core18
+parts:
+  deucalion:
+    plugin: go
+    go-importpath: github.com/roaldnefs/deucalion
+    source: .
+    source-type: git
+    build-packages:
+    - gcc
+
+apps:
+  deucalion:
+    command: bin/deucalion


### PR DESCRIPTION
Documentation: https://snapcraft.io/first-snap/golang

- Add initial support for building a snap package
- Add *.snap extension to gitignore